### PR TITLE
[!!!][BUGFIX] Define correct boolean value in extension configuration

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,2 @@
 # cat=basic/enable; type=boolean; label= ExtensionService: Use alternative implementation of Extbase ExtensionService
-extensionServiceEnabled = false
+extensionServiceEnabled = 0


### PR DESCRIPTION
TypoScript evaluates only `0` as `false` for boolean values and interprets each other non-empty value as truthy, thus the current extension configuration was interpreted to be truthy. As this definitely should not be the default value for this configuration, the default property value `extensionServiceEnabled` has been adapted accordingly.

**This is a breaking change** as it switches the currently by accident defined (evaluated) default value from `true` to `false` (which it already should have been). When updating to this commit or each release including it, make sure to adapt your extension configuration.